### PR TITLE
Fix flexbox by supplying min-height

### DIFF
--- a/src/components/Metadata/Metadata.scss
+++ b/src/components/Metadata/Metadata.scss
@@ -2,7 +2,11 @@
   display: flex;
   flex-direction: row;
   align-items: stretch;
-  flex: 1 1 0px;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0px;
+  min-height: 0px;
+
   &__annotations {
     flex: 2;
     padding-right: 8px;


### PR DESCRIPTION
This also depends on line 5 coming through correctly.  The webpacker builds in Avalon are appearing in the browser as `flex: 1 1;` or `flex: 1 1 0%;` instead of `flex: 1 1 0px;` which is in the source.  Hopefully with this change the webpacker builds as well.

The insight on this fix came from https://medium.com/@stephenbunch/how-to-make-a-scrollable-container-with-dynamic-height-using-flexbox-5914a26ae336