### PR TITLE
Avalon specific fix for safari loading bug.

### DIFF
--- a/src/components/AudioImporter/AudioImporter.Utils.js
+++ b/src/components/AudioImporter/AudioImporter.Utils.js
@@ -20,20 +20,30 @@ export const mapImportErrorMessage = error => {
 
 const importResource = url => {
   return new Promise((resolve, reject) => {
-    const audio = new Audio();
-    const audioURL = url;
-    audio.addEventListener('loadedmetadata', () => {
-      resolve(createNewManifest(MANIFEST_DOMAIN, audioURL, audio.duration));
-    });
-    audio.addEventListener('error', () => {
-      switch (audio.error.code) {
-        case 1:
-          throw 'fetching process aborted by user';
-        case 2:
-          throw 'error occurred when downloading';
-        case 3:
-          throw 'error occurred when decoding';
-        case 4:
+    // const audio = new Audio();
+    // const audioURL = url;
+    // audio.addEventListener('loadedmetadata', () => {
+    //   resolve(createNewManifest(MANIFEST_DOMAIN, audioURL, audio.duration));
+    // });
+    // audio.addEventListener('error', () => {
+    //   switch (audio.error.code) {
+    //     case 1:
+    //       throw 'fetching process aborted by user';
+    //     case 2:
+    //       throw 'error occurred when downloading';
+    //     case 3:
+    //       throw 'error occurred when decoding';
+    //     case 4:
+
+          // TODO: Restore ability to load audio resources
+          // The previous approach of assuming the resource is audio and falling back
+          // to fetching it as a manifest fails on safari over 50% of the time.
+          // Possible solutions include assuming the resource is a manifest first
+          // and falling back to loading it as audio, maknig a HEAD request to get
+          // the content type of the resource and choose only the appropriate path,
+          // passing the content type in as a prop, or determining if there is a
+          // different event that safari is sending in this case (that's not
+          // loadedmetadata or error).
           fetch(url)
             .then(res => {
               if (!res.ok) {
@@ -60,12 +70,12 @@ const importResource = url => {
             .catch(err => {
               reject(err.toString());
             });
-          break;
-        default:
-          throw 'Unknown error with resource.';
-      }
-    });
-    audio.src = audioURL;
+      //     break;
+      //   default:
+      //     throw 'Unknown error with resource.';
+      // }
+    // });
+    // audio.src = audioURL;
   });
 };
 


### PR DESCRIPTION
This is a quick fix for avalon that will need to be undone and fixed for any other use of the timeliner.

The previous approach of assuming the resource is audio and falling back to fetching it as a manifest fails on safari over 50% of the time.  Possible solutions include assuming the resource is a manifest first and falling back to loading it as audio, maknig a HEAD request to get the content type of the resource and choose only the appropriate path, passing the content type in as a prop, or determining if there is a different event that safari is sending in this case (that's not loadedmetadata or error).