### PR TITLE
Assume IIIF manifest and fall back to audio

### DIFF
--- a/src/components/AudioImporter/AudioImporter.Utils.js
+++ b/src/components/AudioImporter/AudioImporter.Utils.js
@@ -20,62 +20,49 @@ export const mapImportErrorMessage = error => {
 
 const importResource = url => {
   return new Promise((resolve, reject) => {
-    // const audio = new Audio();
-    // const audioURL = url;
-    // audio.addEventListener('loadedmetadata', () => {
-    //   resolve(createNewManifest(MANIFEST_DOMAIN, audioURL, audio.duration));
-    // });
-    // audio.addEventListener('error', () => {
-    //   switch (audio.error.code) {
-    //     case 1:
-    //       throw 'fetching process aborted by user';
-    //     case 2:
-    //       throw 'error occurred when downloading';
-    //     case 3:
-    //       throw 'error occurred when decoding';
-    //     case 4:
+    fetch(url)
+      .then(res => {
+        if (!res.ok) {
+          if (res.status === 404) {
+            throw new Error('Resource not found (404)');
+          }
+          console.log(res);
+        }
 
-          // TODO: Restore ability to load audio resources
-          // The previous approach of assuming the resource is audio and falling back
-          // to fetching it as a manifest fails on safari over 50% of the time.
-          // Possible solutions include assuming the resource is a manifest first
-          // and falling back to loading it as audio, maknig a HEAD request to get
-          // the content type of the resource and choose only the appropriate path,
-          // passing the content type in as a prop, or determining if there is a
-          // different event that safari is sending in this case (that's not
-          // loadedmetadata or error).
-          fetch(url)
-            .then(res => {
-              if (!res.ok) {
-                if (res.status === 404) {
-                  throw new Error('Resource not found (404)');
-                }
-                console.log(res);
-              }
-
-              const contentType = res.headers.get('content-type');
-              if (!contentType) {
-                throw new Error(
-                  'No content type on resource, unable to identify.'
-                );
-              }
-              if (contentType.includes('application/json')) {
-                const manifestJSON = res.json();
-                validateManifest(manifestJSON);
-                resolve(manifestJSON);
-              } else {
-                throw new Error(`Content type not recognised ${contentType}`);
-              }
-            })
-            .catch(err => {
-              reject(err.toString());
-            });
-      //     break;
-      //   default:
-      //     throw 'Unknown error with resource.';
-      // }
-    // });
-    // audio.src = audioURL;
+        const contentType = res.headers.get('content-type');
+        if (!contentType) {
+          throw new Error(
+            'No content type on resource, unable to identify.'
+          );
+        }
+        if (contentType.includes('application/json') || contentType.includes('text/plain')) {
+          const manifestJSON = res.json();
+          validateManifest(manifestJSON);
+          resolve(manifestJSON);
+        } else {
+          const audio = new Audio();
+          const audioURL = url;
+          audio.addEventListener('loadedmetadata', () => {
+            resolve(createNewManifest(MANIFEST_DOMAIN, audioURL, audio.duration));
+          });
+          audio.addEventListener('error', () => {
+            switch (audio.error.code) {
+              case 1:
+                throw 'fetching process aborted by user';
+              case 2:
+                throw 'error occurred when downloading';
+              case 3:
+                throw 'error occurred when decoding';
+              default:
+                throw 'Unknown error with resource.';
+            }
+          })
+          audio.src = audioURL;
+        }
+      })
+      .catch(err => {
+        reject(err.toString());
+      });
   });
 };
 

--- a/src/utils/iiifLoader.js
+++ b/src/utils/iiifLoader.js
@@ -128,7 +128,7 @@ const getAudioAnnotations = canvas => {
       annotation =>
         (annotation.motivation === 'painting' &&
           annotation.body &&
-          annotation.body.type === 'Audio') ||
+          (annotation.body.type === 'Audio' || annotation.body.type === 'Sound' || annotation.body.type === 'Video')) ||
         (annotation.body && annotation.body.type === 'Choice')
     )
     .map(annotation => {


### PR DESCRIPTION
Be more lenient on file content type and annotation type (github raw urls return 'text/plain', some cookbook recipes had annotations with type 'Sound' and there isn't any real reason we shouldn't also accept 'Video').  This PR reverts an avalon specific fix in favor of a different flow: manifest -> audio -> error.  I tested locally and was able to load both manifests and audio resources in Chrome and Safari.

Fixes https://bugs.dlib.indiana.edu/browse/VOV-6012.