### PR TITLE
Add static landing page

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,15 +32,17 @@ const { store, persistor } = configureStore(
   callback
 );
 
-render(
-  <Root
-    store={store}
-    persistor={persistor}
-    callback={callback}
-    hasResource={!!resource}
-    noFooter={noFooter === 'true'}
-    noHeader={noHeader === 'true'}
-    noSourceLink={noSourceLink === 'true'}
-  />,
-  document.getElementById('app')
-);
+if (document.getElementById('app')) {
+  render(
+    <Root
+      store={store}
+      persistor={persistor}
+      callback={callback}
+      hasResource={!!resource}
+      noFooter={noFooter === 'true'}
+      noHeader={noHeader === 'true'}
+      noSourceLink={noSourceLink === 'true'}
+    />,
+    document.getElementById('app')
+  );
+}

--- a/src/main.scss
+++ b/src/main.scss
@@ -1,10 +1,13 @@
 @import url('https://fonts.googleapis.com/css?family=Roboto:300,400,500');
 
-*, *:before, *:after {
+*,
+*:before,
+*:after {
   box-sizing: border-box;
 }
 
-body, html {
+body,
+html {
   font-family: 'Roboto', sans-serif;
   margin: 0;
   padding: 0;
@@ -12,6 +15,14 @@ body, html {
   background: #eee;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+.homepage {
+  margin: 20px;
+
+  h1 {
+    font-weight: 500;
+  }
 }
 
 .container {

--- a/src/nunjucks/app.twig
+++ b/src/nunjucks/app.twig
@@ -1,0 +1,4 @@
+---
+title: IIIF Timeliner
+---
+<div id="app"></div>

--- a/src/nunjucks/index.twig
+++ b/src/nunjucks/index.twig
@@ -1,4 +1,22 @@
 ---
-title: IIIF Timeliner
+title: IIIF Timeliner - Home
 ---
-<div id="app"></div>
+<div class="homepage">
+    <h1>IIIF Timeliner</h1>
+    <p>
+        Timeliner is a reimplementation of Variations Audio Timeliner as a web
+        application, using the IIIF Presentation API 3.0. As with the original
+        version, developed as a part of the Variations Digital Music Library
+        System, it is an audio annotation and analysis tool for creating and
+        labeling bubble diagrams. These diagrams can be used to navigate music
+        or other audio for detailed study.
+    </p>
+    <p>
+        In addition to its use as a standalone application, the Timeliner is
+        available as integrated feature within the successor to Variations,
+        Avalon Media System. Avalon users can create new bubble diagrams
+        directly from item pages within their Avalon instance and edit, share
+        and copy timelines across all items in the repository.
+    </p>
+    <a href="/app/index.html">Click here to access the Timeliner</a>
+</div>


### PR DESCRIPTION
Adding a new .twig template creates a new static HTML.
Therefore changed `/nunjucks/index.twig` to act as a homepage with the text and added `app.twig` file to render the timeliner React application. 

This is the new landing page;

![Screenshot from 2020-06-29 12-38-47](https://user-images.githubusercontent.com/1331659/86032558-8b20b200-ba05-11ea-9a49-d4d3855b94b9.png)
