### PR TITLE
Sample usage of the Video component in Timeliner

### DIFF
--- a/src/components/Metadata/Metadata.js
+++ b/src/components/Metadata/Metadata.js
@@ -6,6 +6,7 @@ import MetadataDisplay from '../MetadataDisplay/MetadataDisplay';
 import MetadataEditor from '../MetadataEditor/MetadataEditor';
 import ProjectMetadataDisplay from '../ProjectMetadataDisplay/ProjectMetadataDisplay';
 import ProjectMetadataEditor from '../ProjectMetadataEditor/ProjectMetadataEditor';
+import Video from '../../containers/Video/Video';
 
 import './Metadata.scss';
 import MarkerMetadata from '../MarkerMetadata/MarkerMetadata';
@@ -121,6 +122,20 @@ const Metadata = props => {
           </div>
         </div>
       </div>
+      {props.isVideo && (
+        <div className="metadata__video-playback">
+          <div className="metadata__video-playback-content">
+            <Typography
+              variant="subtitle1"
+              color="textSecondary"
+              style={{ marginBottom: 10 }}
+            >
+              Video Playback
+            </Typography>
+              <Video />
+          </div>
+        </div>
+      )} 
       <div className="metadata__project">
         <div className="metadata__project-content">
           <Typography

--- a/src/components/Metadata/Metadata.scss
+++ b/src/components/Metadata/Metadata.scss
@@ -24,6 +24,23 @@
     overflow-x: hidden;
   }
 
+  &__video-playback {
+    flex: 1;
+    padding-right: 8px;
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__video-playback-content {
+    background: white;
+    padding: 8px 16px;
+    flex: 1 1 0px;
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    overflow-x: hidden;
+  }
+
   &__project {
     flex: 1 1 0px;
     display: flex;

--- a/src/containers/VariationsMainView/VariationsMainView.js
+++ b/src/containers/VariationsMainView/VariationsMainView.js
@@ -318,6 +318,9 @@ class VariationsMainView extends React.Component {
                 setCurrentTime={this.props.setCurrentTime}
                 undoAll={this.props.canUndo ? this.props.undoAll : null}
                 swatch={this.props.colourPalette.colours}
+                // Enable Video playback in the timeliner
+                isVideo={!noVideo && this.props.isVideo}
+                poster={this.props.poster}
               />
               {!noFooter && <Footer />}
             </div>
@@ -396,6 +399,8 @@ const mapStateProps = state => ({
   authService: state.canvas.service,
   annotationPages: state.canvas.items,
   url: state.canvas.url,
+  isVideo: state.canvas.isVideo,
+  poster: state.canvas.poster,
   runTime: state.viewState.runTime,
   manifestLabel: state.project.title,
   importError: state.project.error,


### PR DESCRIPTION
This PR contains an example code for adding the Video component to the Timeliner as seen the screenshot below;
![timeliner-shared](https://user-images.githubusercontent.com/1331659/193355642-00b168d2-3555-41bd-883d-178d894556de.png)

This PR do not need to be merged.