### PR TITLE
[a11y] Disable buttons and scrubber when modal dialogs are open

### DIFF
--- a/src/components/AudioTransportBar/AudioTransportBar.js
+++ b/src/components/AudioTransportBar/AudioTransportBar.js
@@ -44,6 +44,8 @@ class AudioTransportBar extends Component {
     onGroupBubble: PropTypes.func,
     /** Deletes the selected bubble */
     onDeleteBubble: PropTypes.func,
+    /** Boolean value used for disabling components when modal is open */
+    isModalOpen: PropTypes.bool.isRequired,
   };
 
   keyboardListener = e => {
@@ -108,7 +110,7 @@ class AudioTransportBar extends Component {
           <Grid item xs={4} className="audio-transport-bar__actions">
             <CurrentTimeIndicator currentTime={currentTime} runtime={runTime} />
             <PrimaryButton
-              disabled={!onAddBubble}
+              disabled={!onAddBubble || this.props.isModalOpen}
               onClick={onAddBubble}
               style={{ padding: 4 }}
               size="small"
@@ -126,7 +128,7 @@ class AudioTransportBar extends Component {
               </Tooltip>
             </PrimaryButton>
             <PrimaryButton
-              disabled={!onAddMarker}
+              disabled={!onAddMarker || this.props.isModalOpen}
               onClick={onAddMarker}
               style={{ marginLeft: 16, padding: 4 }}
               size="small"
@@ -145,7 +147,7 @@ class AudioTransportBar extends Component {
             </PrimaryButton>
 
             <PrimaryButton
-              disabled={!onGroupBubble}
+              disabled={!onGroupBubble || this.props.isModalOpen}
               onClick={onGroupBubble}
               style={{ marginLeft: 16, padding: 4 }}
               size="small"
@@ -163,7 +165,7 @@ class AudioTransportBar extends Component {
               </Tooltip>
             </PrimaryButton>
             <PrimaryButton
-              disabled={!onDeleteBubble}
+              disabled={!onDeleteBubble || this.props.isModalOpen}
               onClick={onDeleteBubble}
               style={{ marginLeft: 16, padding: 4 }}
               size="small"
@@ -183,15 +185,16 @@ class AudioTransportBar extends Component {
           </Grid>
           <Grid item xs={4}>
             <div className="audio-transport-bar__buttons">
-              <PreviousButton onClick={onPreviousBubble} />
-              <SkipBackwardsButton onClick={onScrubBackwards} />
+              <PreviousButton onClick={onPreviousBubble} disabled={this.props.isModalOpen} />
+              <SkipBackwardsButton onClick={onScrubBackwards} disabled={this.props.isModalOpen} />
               <PlayPauseButton
                 isPlaying={isPlaying}
                 onPlay={onPlay}
                 onPause={onPause}
+	        disabled={this.props.isModalOpen}
               />
-              <SkipAheadButton onClick={onScrubAhead} />
-              <NextButton onClick={onNextBubble} />
+              <SkipAheadButton onClick={onScrubAhead} disabled={this.props.isModalOpen} />
+              <NextButton onClick={onNextBubble} disabled={this.props.isModalOpen} />
             </div>
           </Grid>
 
@@ -200,6 +203,7 @@ class AudioTransportBar extends Component {
               onZoomIn={this.props.zoomIn}
               onZoomOut={zoom > 1 ? this.props.zoomOut : null}
               onResetView={zoom !== 1 ? this.props.resetZoom : null}
+	      disabled={this.props.isModalOpen}
             />
           </Grid>
 
@@ -208,6 +212,7 @@ class AudioTransportBar extends Component {
               flipped={true}
               volume={volume}
               onVolumeChanged={onVolumeChanged}
+	      disabled={this.props.isModalOpen}
             />
           </Grid>
         </Grid>

--- a/src/components/Metadata/Metadata.js
+++ b/src/components/Metadata/Metadata.js
@@ -168,6 +168,7 @@ const Metadata = props => {
                 canErase={props.canErase}
                 undoAll={props.undoAll}
                 hasResource={props.hasResource}
+		isModalOpen={props.isModalOpen}
               />
             )}
           </div>
@@ -225,6 +226,8 @@ Metadata.propTypes = {
   deleteMarker: PropTypes.func,
   /** Media url */
   url: PropTypes.string,
+  /** Boolean value used for disabling components when modal is open */
+  isModalOpen: PropTypes.bool.isRequired,
 };
 
 Metadata.defaultProps = {

--- a/src/components/ProjectMetadataDisplay/ProjectMetadataDisplay.js
+++ b/src/components/ProjectMetadataDisplay/ProjectMetadataDisplay.js
@@ -33,7 +33,7 @@ const ProjectMetadataDisplay = props => (
         <a href={props.homepage} target="_top">{props.homepageLabel}</a>
       </Typography>
     )}
-    {!props.noSourceLink && (!props.homepage || !props.homepageLabel) && (
+    {!props.noSourceLink && (!props.homepage || !props.homepageLabel) && props.url && (
       <div>
         <Typography
           variant="subtitle1"
@@ -67,6 +67,7 @@ const ProjectMetadataDisplay = props => (
             variant="text"
             color="primary"
             onClick={props.onSaveButtonClicked}
+	    disabled={props.isModalOpen}
             title="Download timeline"
           >
             <CloudDownload nativeColor="#FF4081" style={{ marginRight: 20 }} />
@@ -80,6 +81,7 @@ const ProjectMetadataDisplay = props => (
             variant="text"
             color="primary"
             onClick={props.onEraseButtonClicked}
+	    disabled={props.isModalOpen}
             title="Start timeline over"
           >
             <RestorePage nativeColor="#303F9F" style={{ marginRight: 20 }} />
@@ -92,7 +94,7 @@ const ProjectMetadataDisplay = props => (
             variant="text"
             color="primary"
             onClick={props.undoAll}
-            disabled={!props.undoAll}
+            disabled={!props.undoAll || props.isModalOpen}
             title="Revert changes"
           >
             <RestorePage
@@ -120,6 +122,7 @@ ProjectMetadataDisplay.propTypes = {
   canErase: PropTypes.bool,
   canSave: PropTypes.bool,
   hasResource: PropTypes.bool,
+  isModalOpen: PropTypes.bool.isRequired,
 };
 
 export default ProjectMetadataDisplay;

--- a/src/components/TimelineScrubber/TimelineScrubber.js
+++ b/src/components/TimelineScrubber/TimelineScrubber.js
@@ -59,6 +59,8 @@ class TimelineScrubber extends Component {
     }),
     /** When a point is clicked */
     onClickPoint: PropTypes.func,
+    /** Boolean value used for disabling components when modal is open */
+    isModalOpen: PropTypes.bool.isRequired,
   };
 
   static defaultProps = {
@@ -165,7 +167,7 @@ class TimelineScrubber extends Component {
         ref={ref => (this.container = ref)}
         className={$style}
         onDoubleClick={this.handleAddPoint}
-        tabIndex={0}
+        tabIndex={this.props.isModalOpen ? -1 : 0}
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseMove={this.onMouseMove}

--- a/src/components/VariationsAppBar/VariationsAppBar.js
+++ b/src/components/VariationsAppBar/VariationsAppBar.js
@@ -47,6 +47,7 @@ const VariationsAppBar = props => (
             color="inherit"
             onClick={props.onImportButtonClicked}
             title="Open media file"
+            disabled={props.isModalOpen}
           >
             <AddCircle />
           </IconButton>
@@ -56,6 +57,7 @@ const VariationsAppBar = props => (
             color="inherit"
             onClick={props.onSave}
             title={props.onSave ? 'Save timeline' : 'No backend set up to save'}
+	    disabled={props.isModalOpen}
           >
             <Save />
           </IconButton>
@@ -63,7 +65,7 @@ const VariationsAppBar = props => (
         <IconButton
           color="inherit"
           onClick={props.onUndo}
-          disabled={(props.canUndo || false) === false}
+          disabled={((props.canUndo || false) === false) || props.isModalOpen}
           title="Undo"
         >
           <Undo />
@@ -71,7 +73,7 @@ const VariationsAppBar = props => (
         <IconButton
           color="inherit"
           onClick={props.onRedo}
-          disabled={(props.canRedo || false) === false}
+          disabled={((props.canRedo || false) === false) || props.isModalOpen}
           title="Redo"
         >
           <Redo />
@@ -80,6 +82,7 @@ const VariationsAppBar = props => (
           color="inherit"
           onClick={props.onSettingsButtonClicked}
           title="Settings"
+	  disabled={props.isModalOpen}
         >
           <Settings />
         </IconButton>
@@ -100,6 +103,8 @@ VariationsAppBar.propTypes = {
   /** Opens the project settings modal */
   onSettingsButtonClicked: PropTypes.func.isRequired,
   noHeader: PropTypes.bool,
+  /** Boolean value used for disabling components when modal is open */
+  isModalOpen: PropTypes.bool.isRequired,
 };
 
 export default VariationsAppBar;

--- a/src/components/VolumeSliderCompact/VolumeSliderCompact.js
+++ b/src/components/VolumeSliderCompact/VolumeSliderCompact.js
@@ -24,6 +24,7 @@ class VolumeSliderCompact extends Component {
     onVolumeChanged: PropTypes.func.isRequired,
     /** Flip the order of the slider and icon */
     flipped: PropTypes.bool,
+    disabled: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -62,6 +63,7 @@ class VolumeSliderCompact extends Component {
           value={volume}
           onChange={this.onVolumeInputChange}
           aria-label="Volume"
+	  disabled={this.props.disabled}
         />
         <div className={$style.element('muter')} onClick={this.onToggle}>
           {volume === 0 ? (

--- a/src/components/ZoomControls/ZoomControls.js
+++ b/src/components/ZoomControls/ZoomControls.js
@@ -10,21 +10,21 @@ const ZoomControls = props => (
   <div className="zoom-controls">
     <IconButton
       onClick={props.onZoomIn}
-      disabled={!props.onZoomIn}
+      disabled={!props.onZoomIn || props.disabled}
       title="Zoom In"
     >
       <ZoomIn />
     </IconButton>
     <IconButton
       onClick={props.onResetView}
-      disabled={!props.onResetView}
+      disabled={!props.onResetView || props.disabled}
       title="Reset View"
     >
       <YoutubeSearchedFor />
     </IconButton>
     <IconButton
       onClick={props.onZoomOut}
-      disabled={!props.onZoomOut}
+      disabled={!props.onZoomOut || props.disabled}
       title="Zoom Out"
     >
       <ZoomOut />
@@ -39,12 +39,14 @@ ZoomControls.propTypes = {
   onZoomOut: PropTypes.func,
   /** Handler for resetting view */
   onResetView: PropTypes.func,
+  disabled: PropTypes.bool,
 };
 
 ZoomControls.defaultProps = {
   onZoomIn: null,
   onZoomOut: null,
   onResetView: null,
+  disabled: false,
 };
 
 export default ZoomControls;

--- a/src/containers/BubbleEditor/BubbleEditor.js
+++ b/src/containers/BubbleEditor/BubbleEditor.js
@@ -148,6 +148,7 @@ class BubbleEditor extends React.Component {
       selectedPoints,
       colourPalette,
       startTime,
+      isModalOpen,
     } = this.props;
 
     const timePoints = this.getTimePoints();
@@ -218,6 +219,7 @@ class BubbleEditor extends React.Component {
                   isPlayheadUpdating={playhead.isUpdating}
                   playheadX={playhead.x}
                   markers={this.props.markers}
+		  isModalOpen={this.props.isModalOpen}
                 />
               </div>
             )}

--- a/src/containers/VariationsMainView/VariationsMainView.js
+++ b/src/containers/VariationsMainView/VariationsMainView.js
@@ -236,6 +236,7 @@ class VariationsMainView extends React.Component {
             onTitleChange={() => {}}
             hasResource={this.props.hasResource}
             noHeader={this.props.noHeader}
+	    isModalOpen={this.props.isImportOpen || this.props.isSettingsOpen}
           />
           <div className="variations-app__content">
             <AuthCookieService1
@@ -245,7 +246,10 @@ class VariationsMainView extends React.Component {
                 this.props.authService ? this.props.authService[0] : null
               }
             >
-              <BubbleEditor key={'bubble--' + this.props.url} />
+              <BubbleEditor
+	        key={'bubble--' + this.props.url}
+	        isModalOpen={this.props.isImportOpen || this.props.isSettingsOpen}
+	      />
               {this.props.url ? (
                 <Audio key={'audio--' + this.props.url} />
               ) : null}
@@ -282,6 +286,7 @@ class VariationsMainView extends React.Component {
                 zoomIn={this.props.zoomIn}
                 zoomOut={this.props.zoomOut}
                 resetZoom={this.props.resetZoom}
+	        isModalOpen={this.props.isImportOpen || this.props.isSettingsOpen}
               />
             </AuthCookieService1>
             <div className="variations-app__metadata-editor">
@@ -321,6 +326,7 @@ class VariationsMainView extends React.Component {
                 // Enable Video playback in the timeliner
                 isVideo={!noVideo && this.props.isVideo}
                 poster={this.props.poster}
+	        isModalOpen={this.props.isImportOpen || this.props.isSettingsOpen}
               />
               {!noFooter && <Footer />}
             </div>


### PR DESCRIPTION
Modal dialogs are implemented using MaterialUI Dialog class.  Dialog elements block navigation outside the modal using JS and sets the rest of the page aria-hidden but does not do anyother changes to the underlying page.  This leaves accessibility checkers like SiteImprove to detect navigable aria-hidden elements.  This feels a bit like a false positive but this PR does the work to disable those interactive elements when modal dialogs are open.

Note that this PR seems to introduce a new SiteImprove warning because the "Download this timeline" and "Start this timeline over" buttons drop below minimum contrast when disabled with the modal open.