### PR TITLE
Fix CSS issues with latest build fixes

### DIFF
--- a/src/components/MetadataEditor/MetadataEditor.jsx
+++ b/src/components/MetadataEditor/MetadataEditor.jsx
@@ -111,7 +111,7 @@ class MetadataEditor extends Component {
       whiteText,
     } = this.state;
     return (
-      <form className='metadata-editor'onKeyDown={this.handleKeyDown}>
+      <form className='metadata-editor' onKeyDown={this.handleKeyDown}>
         <TextField
           id="label"
           autoFocus={true}

--- a/src/components/Playhead/Playhead.scss
+++ b/src/components/Playhead/Playhead.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 .playhead {
   position: absolute;
   background: #FF4081;
@@ -51,7 +53,7 @@
   //  border-right: 5px solid transparent;
   //}
   .playhead:before {
-    background: mix(#FF4081, #000, 70%);
+    background: color.mix(#FF4081, #000, 70%);
     transform: scale(1);
   }
 }

--- a/src/components/TimelineMarker/TimelineMarker.jsx
+++ b/src/components/TimelineMarker/TimelineMarker.jsx
@@ -37,7 +37,7 @@ class TimelineMarker extends Component {
 
     return (
       <div
-        className={bookmark ? 'timeline-marker--bookmark' : 'timeline-marker--marker'}
+        className={`timeline-marker ${bookmark ? 'timeline-marker--bookmark' : 'timeline-marker--marker'}`}
         style={{ left: `${x}%` }}
         onMouseDown={onMouseDown}
       >

--- a/src/components/VolumeSliderCompact/VolumeSliderCompact.jsx
+++ b/src/components/VolumeSliderCompact/VolumeSliderCompact.jsx
@@ -53,7 +53,7 @@ class VolumeSliderCompact extends Component {
     const { volume, flipped } = this.props;
 
     return (
-      <div className={flipped ? 'volume-slider-compact--flipped' : 'volume-slider-compact'}>
+      <div className={flipped ? 'volume-slider-compact volume-slider-compact--flipped' : 'volume-slider-compact'}>
         <Slider
           min={0}
           max={100}


### PR DESCRIPTION
Related issue: #70 

This PR includes:
- Fixes to CSS classes in `TimelineMarker` and `VolumeSlideCompact` components
- Fix to the following deprecation warning when compiling CSS,
```
Deprecation Warning [global-builtin]: Global built-in functions are deprecated and will be removed in Dart Sass 3.0.0.
Use color.mix instead.

More info and automated migrator: https://sass-lang.com/d/import

   ╷
54 │     background: mix(#FF4081, #000, 70%);
   │                 ^^^^^^^^^^^^^^^^^^^^^^^
```