### PR TITLE
Fix a11y in MUI v3 slider & video player and fix broken volume change handler

### DIFF
--- a/src/components/VolumeSlider/VolumeSlider.jsx
+++ b/src/components/VolumeSlider/VolumeSlider.jsx
@@ -1,8 +1,9 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Slider from '@material-ui/lab/Slider';
 import VolumeDown from '@material-ui/icons/VolumeDown';
 import VolumeUp from '@material-ui/icons/VolumeUp';
+import useVolumeSlider from '../../hooks/useVolumeSlider';
 import './VolumeSlider.scss';
 
 const SPEAKER_ICON_SIZE = {
@@ -10,39 +11,38 @@ const SPEAKER_ICON_SIZE = {
   height: 20,
 };
 
-class VolumeSlider extends Component {
-  static propTypes = {
-    /** Current volume value */
-    volume: PropTypes.number.isRequired,
-    /** Handler for when volume is changed */
-    onVolumeChanged: PropTypes.func.isRequired,
-  };
-  static defaultProps = {
-    volume: 100,
-  };
+function VolumeSlider({ volume, onVolumeChanged }) {
+  const { containerRef, onVolumeInputChange } = useVolumeSlider(volume, onVolumeChanged);
 
-  onVolumeInputChange = (ev, value) => {
-    const { onVolumeChanged } = this.props;
-    if (onVolumeChanged) {
-      onVolumeChanged(parseInt(value, 10));
-    }
-  };
-
-  render() {
-    const { volume } = this.props;
-    return (
-      <div className="volume-slider">
-        <VolumeDown color="disabled" style={SPEAKER_ICON_SIZE} />
-        <Slider
-          min={0}
-          max={100}
-          value={volume}
-          onChange={this.onVolumeInputChange}
-        />
-        <VolumeUp color="disabled" style={SPEAKER_ICON_SIZE} />
-      </div>
-    );
-  }
+  return (
+    <div
+      ref={containerRef}
+      className="volume-slider"
+      role="group"
+      aria-label="Volume control"
+    >
+      <VolumeDown color="disabled" style={SPEAKER_ICON_SIZE} aria-hidden="true" />
+      <Slider
+        min={0}
+        max={100}
+        value={volume}
+        onChange={onVolumeInputChange}
+        aria-label="Volume"
+      />
+      <VolumeUp color="disabled" style={SPEAKER_ICON_SIZE} aria-hidden="true" />
+    </div>
+  );
 }
+
+VolumeSlider.propTypes = {
+  /** Current volume value */
+  volume: PropTypes.number.isRequired,
+  /** Handler for when volume is changed */
+  onVolumeChanged: PropTypes.func.isRequired,
+};
+
+VolumeSlider.defaultProps = {
+  volume: 100,
+};
 
 export default VolumeSlider;

--- a/src/components/VolumeSliderCompact/VolumeSliderCompact.jsx
+++ b/src/components/VolumeSliderCompact/VolumeSliderCompact.jsx
@@ -1,85 +1,90 @@
-import React, { Component } from 'react';
+import { useState } from 'react';
 import './VolumeSliderCompact.scss';
 import PropTypes from 'prop-types';
 import VolumeUp from '@material-ui/icons/VolumeUp';
 import VolumeDown from '@material-ui/icons/VolumeDown';
 import VolumeOff from '@material-ui/icons/VolumeOff';
 import Slider from '@material-ui/lab/Slider';
+import useVolumeSlider from '../../hooks/useVolumeSlider';
 
 const SPEAKER_ICON_SIZE = {
   width: 20,
   height: 20,
 };
 
-class VolumeSliderCompact extends Component {
-  state = { previousVolume: null };
+function VolumeSliderCompact({ volume, onVolumeChanged, flipped, disabled }) {
+  const [previousVolume, setPreviousVolume] = useState(null);
 
-  static propTypes = {
-    /** Current volume value */
-    volume: PropTypes.number.isRequired,
-    /** Handler for when volume is changed */
-    onVolumeChanged: PropTypes.func.isRequired,
-    /** Flip the order of the slider and icon */
-    flipped: PropTypes.bool,
-    disabled: PropTypes.bool,
-  };
+  const { containerRef, onVolumeInputChange } = useVolumeSlider(
+    volume,
+    onVolumeChanged,
+    { muteButtonSelector: '.volume-slider-compact__muter' }
+  );
 
-  static defaultProps = {
-    volume: 100,
-    flipped: false,
-  };
-
-  onVolumeInputChange = (ev, value) => {
-    const { onVolumeChanged } = this.props;
-    if (onVolumeChanged) {
-      onVolumeChanged(parseInt(value, 10));
-    }
-  };
-
-  onToggle = () => {
-    const { volume, onVolumeChanged } = this.props;
-    const { previousVolume } = this.state;
+  const onToggle = () => {
     if (onVolumeChanged) {
       if (volume === 0) {
         onVolumeChanged(previousVolume || 100);
       } else {
-        this.setState({ previousVolume: volume });
+        setPreviousVolume(volume);
         onVolumeChanged(0);
       }
     }
   };
 
-  render() {
-    const { volume, flipped } = this.props;
-
-    return (
-      <div className={flipped ? 'volume-slider-compact volume-slider-compact--flipped' : 'volume-slider-compact'}>
-        <Slider
-          min={0}
-          max={100}
-          value={volume}
-          onChange={this.onVolumeInputChange}
-          aria-label="Volume"
-	  disabled={this.props.disabled}
-        />
-        <div className='volume-slider-compact__muter' onClick={this.onToggle}>
-          {volume === 0 ? (
-            <VolumeOff
-              style={{ ...SPEAKER_ICON_SIZE, transform: 'translateX(1px)' }}
-            />
-          ) : volume <= 40 ? (
-            <VolumeDown
-              style={{ ...SPEAKER_ICON_SIZE, transform: 'translateX(-0.5px)' }}
-            />
-          ) : (
-            <VolumeUp
-              style={{ ...SPEAKER_ICON_SIZE, transform: 'translateX(1px)' }}
-            />
-          )}
-        </div>
-      </div>
-    );
-  }
+  return (
+    <div
+      ref={containerRef}
+      className={flipped ? 'volume-slider-compact volume-slider-compact--flipped' : 'volume-slider-compact'}
+      role="group"
+      aria-label="Volume control"
+    >
+      <Slider
+        min={0}
+        max={100}
+        value={volume}
+        onChange={onVolumeInputChange}
+        aria-label="Volume"
+        disabled={disabled}
+      />
+      <button
+        className='volume-slider-compact__muter'
+        onClick={onToggle}
+        aria-label={volume === 0 ? "Unmute" : "Mute"}
+        disabled={disabled}
+        type="button"
+      >
+        {volume === 0 ? (
+          <VolumeOff
+            style={{ ...SPEAKER_ICON_SIZE, transform: 'translateX(1px)' }}
+          />
+        ) : volume <= 40 ? (
+          <VolumeDown
+            style={{ ...SPEAKER_ICON_SIZE, transform: 'translateX(-0.5px)' }}
+          />
+        ) : (
+          <VolumeUp
+            style={{ ...SPEAKER_ICON_SIZE, transform: 'translateX(1px)' }}
+          />
+        )}
+      </button>
+    </div>
+  );
 }
+
+VolumeSliderCompact.propTypes = {
+  /** Current volume value */
+  volume: PropTypes.number.isRequired,
+  /** Handler for when volume is changed */
+  onVolumeChanged: PropTypes.func.isRequired,
+  /** Flip the order of the slider and icon */
+  flipped: PropTypes.bool,
+  disabled: PropTypes.bool,
+};
+
+VolumeSliderCompact.defaultProps = {
+  volume: 100,
+  flipped: false,
+};
 
 export default VolumeSliderCompact;

--- a/src/components/VolumeSliderCompact/VolumeSliderCompact.scss
+++ b/src/components/VolumeSliderCompact/VolumeSliderCompact.scss
@@ -16,5 +16,12 @@
 
   &__muter {
     margin: 0 10px;
+    background: none;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
   }
 }

--- a/src/containers/Video/Video.jsx
+++ b/src/containers/Video/Video.jsx
@@ -14,7 +14,7 @@ const { MediaElement } = window;
 function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeked, ...props }) {
   const video = useRef();
   const player = useRef();
-  const sources = [{ src: url}];
+  const sources = [{ src: url }];
   const lastTime = useRef(() => startTime - 1);
   const lastVolume = useRef();
   const [pipButtonText, setPipButtonText] = useState('Enter Picture-in-Picture mode');
@@ -60,10 +60,10 @@ function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeke
             });
         } else {
           videoElement
-          .requestPictureInPicture()
-          .catch(error => {
-            console.error('Error -> requestPictureInPicture() -> ', error);
-          });
+            .requestPictureInPicture()
+            .catch(error => {
+              console.error('Error -> requestPictureInPicture() -> ', error);
+            });
         }
       });
     }
@@ -76,7 +76,7 @@ function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeke
     videoElement.addEventListener('leavepictureinpicture', () => {
       setPipButtonText('Enter Picture-in-Picture mode');
     });
-  }
+  };
 
   // Re-create player instance with media swap
   // TODO:: There's a slight time difference in the video and audio
@@ -85,7 +85,7 @@ function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeke
   // -> swap media file with 'Open audio file' in toolbar ->
   // play media -> observe currentTime diff in the audio and video players
   useLayoutEffect(() => {
-    if(url != null && player.current == null) {
+    if (url != null && player.current == null) {
       player.current = new MediaElement(
         video.current,
         {
@@ -101,10 +101,10 @@ function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeke
   // Store last non-zero volume to restore it 
   // when using PiP controls
   useLayoutEffect(() => {
-    if(volume > 0) {
+    if (volume > 0) {
       lastVolume.current = volume;
     }
-  }, [volume])
+  }, [volume]);
 
   // Propagate play/pause and mute/unmute events from the picture-in-picture
   // player window to audio player
@@ -115,7 +115,7 @@ function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeke
     props.pause();
   }, [url]);
   useEventListener(player, 'volumechange', () => {
-    if(player.current.muted) {
+    if (player.current.muted) {
       props.setVolume(0);
     } else {
       props.setVolume(lastVolume.current);
@@ -123,7 +123,7 @@ function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeke
   }, [volume, url]);
   useEventListener(player, 'loadedmetadata', () => {
     initPIP();
-  })
+  });
 
   // Handle play/pause events from the audio player
   useLayoutEffect(() => {
@@ -166,13 +166,17 @@ function Video({ url, volume, currentTime, startTime, isPlaying, poster, isSeeke
 
   return (
     <div style={videoDivStyle}>
-      <video height={270} width={480} ref={video} poster={poster} style={videoStyle}>
+      <video height={270} width={480} ref={video} poster={poster} style={videoStyle}
+        aria-label="Timeliner video player"
+        tabIndex={0}
+      >
       </video>
       <Button
         variant="text"
         id="timeliner-pip-button"
         color="primary"
         title="Picture-in-Picture mode"
+        aria-label={pipButtonText}
         style={pipButtonStyles}
       >
         <PictureInPicture nativeColor="#FF4081" style={{ marginRight: 20 }} />

--- a/src/hooks/useVolumeSlider.js
+++ b/src/hooks/useVolumeSlider.js
@@ -1,0 +1,70 @@
+import { useRef, useCallback, useEffect } from 'react';
+
+/**
+ * Custom hook for managing volume slider logic
+ * Handles volume changes and a11y enhancements for Material-UI v3 slider
+ *
+ * @param {Number} volume current volume value (0-100)
+ * @param {Function} onVolumeChanged callback function when volume changes
+ * @param {Object} options optional configuration
+ * @returns {
+ *  containerRef, onVolumeInputChange
+ * }
+ */
+export default function useVolumeSlider(volume, onVolumeChanged, options = {}) {
+  const { muteButtonSelector } = options;
+  const containerRef = useRef();
+
+  const onVolumeInputChange = useCallback((e) => {
+    // Calculate the volume based on mouse X position
+    const rect = e.currentTarget.getBoundingClientRect();
+    const x = e.clientX - rect.left;
+    const y = e.clientY - rect.top;
+    const volumeValue = (x / rect.width) * 100 || 100;
+    if (onVolumeChanged) {
+      onVolumeChanged(parseInt(volumeValue, 10));
+    }
+  }, [onVolumeChanged]);
+
+  const enhanceSliderAccessibility = useCallback(() => {
+    // Fix Material-UI v3 accessibility issue: remove role="slider" from container div
+    // since it contains a button, which creates nested interactive controls
+    const sliderContainer = containerRef.current;
+    if (sliderContainer) {
+      // Find the Material-UI slider container div with role="slider"
+      const sliderDiv = sliderContainer.querySelector('[role="slider"]');
+      if (sliderDiv) {
+        // Remove the role from slider since it's not the actual interactive element
+        sliderDiv.removeAttribute('role');
+        const attributes = sliderDiv.getAttributeNames();
+        // Remove all aria-* attributes to match with its role removal
+        attributes.forEach(attrName => {
+          if (attrName.startsWith('aria-')) {
+            sliderDiv.removeAttribute(attrName);
+          }
+        });
+      }
+
+      // Find the volume thumb and make it accessible, omit mute/unmute button using muteButtonSelector
+      const buttonSelector = muteButtonSelector
+        ? `button:not(${muteButtonSelector})`
+        : 'button';
+      const thumbButton = sliderContainer.querySelector(buttonSelector);
+      if (thumbButton) {
+        thumbButton.setAttribute('role', 'slider');
+        thumbButton.setAttribute('aria-label', 'Volume');
+        thumbButton.setAttribute('aria-valuemin', '0');
+        thumbButton.setAttribute('aria-valuemax', '100');
+        thumbButton.setAttribute('aria-valuenow', String(volume));
+        thumbButton.setAttribute('aria-valuetext', `${volume} percent`);
+        thumbButton.setAttribute('aria-orientation', 'horizontal');
+      }
+    }
+  }, [volume, muteButtonSelector]);
+
+  useEffect(() => {
+    enhanceSliderAccessibility();
+  }, [enhanceSliderAccessibility]);
+
+  return { containerRef, onVolumeInputChange };
+}


### PR DESCRIPTION
Related issue: #76 

Additionally, fix the volume change handler which was broken (reproduce-able in timeliner in Avalon) due to the event handler always receiving a NaN value for the volume.
Since both `VolumeSlider` and `VolumeSliderCompact` shares identical code, I pulled the duplicated code into a custom hook in this PR.