### PR TITLE
Fix keybaord nav for color palettes in settings modal

### DIFF
--- a/src/components/ColorPaletteSwitcher/ColorPaletteSwitcher.jsx
+++ b/src/components/ColorPaletteSwitcher/ColorPaletteSwitcher.jsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import FormControl from '@material-ui/core/FormControl';
+import FormLabel from '@material-ui/core/FormLabel';
+import RadioGroup from '@material-ui/core/RadioGroup';
+import Radio from '@material-ui/core/Radio';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import { colourPalettes } from '../../config';
+import './ColorPaletteSwitcher.scss';
+
+// Render each color preview swatch with name
+const PalettePreview = ({ name, colors }) => (
+  <div className="color-palette-switcher__preview">
+    <div className="color-palette-switcher__name">{name}</div>
+    <div className="color-palette-switcher__swatches">
+      {colors.map(color => (
+        <div
+          key={color}
+          className="color-palette-switcher__swatch"
+          style={{ backgroundColor: color }}
+          aria-hidden="true"
+        />
+      ))}
+    </div>
+  </div>
+);
+
+PalettePreview.propTypes = {
+  name: PropTypes.string.isRequired,
+  colors: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+const ColorPaletteSwitcher = ({ currentKey, onChange }) => {
+  return (
+    <FormControl component="fieldset" className="color-palette-switcher" fullWidth={true}>
+      <FormLabel component="legend">
+        Select a color palette
+      </FormLabel>
+      <RadioGroup
+        aria-label="color palette options"
+        name="colorPalette"
+        value={currentKey}
+        onChange={(event) => onChange(event.target.value)}
+        style={{ marginTop: 16 }}
+      >
+        {Object.keys(colourPalettes).map(key => {
+          const palette = colourPalettes[key];
+          const isChecked = currentKey === key;
+          return (
+            <FormControlLabel
+              key={key}
+              value={key}
+              checked={isChecked}
+              control={<Radio color="primary" disableRipple />}
+              label={
+                <PalettePreview
+                  name={palette.name}
+                  colors={palette.colours}
+                />
+              }
+              labelPlacement="end"
+              className={`color-palette-switcher__option ${isChecked ? 'is-selected' : ''}`}
+            />
+          );
+        })}
+      </RadioGroup>
+    </FormControl>
+  );
+};
+
+ColorPaletteSwitcher.propTypes = {
+  /** Selected palette key */
+  currentKey: PropTypes.string.isRequired,
+  /** Change handler to update palette selection */
+  onChange: PropTypes.func.isRequired,
+};
+
+export default ColorPaletteSwitcher;

--- a/src/components/ColorPaletteSwitcher/ColorPaletteSwitcher.mdx
+++ b/src/components/ColorPaletteSwitcher/ColorPaletteSwitcher.mdx
@@ -1,0 +1,31 @@
+---
+title: Color palette switcher
+menu: Components
+---
+
+import { Playground, Props } from 'docz';
+import ColorPaletteSwitcher from './ColorPaletteSwitcher';
+import { PROJECT } from '../../constants/project';
+
+# Color palette switcher
+Creates a keyboard accessible radio button groups for listing and selecting a desired color palette for the bubbles
+
+<Props of={ColorPaletteSwitcher} />
+
+## Color Palette Switcher Demo
+<Playground>
+  <div style={{width: '100%', height: 500 }}>
+    <ColorPaletteSwitcher />
+  </div>
+</Playground>
+
+
+## Color Palette Switcher Demo
+<Playground>
+  <div style={{width: '100%', height: 500 }}>
+    <ColorPaletteSwitcher 
+      currentKey={'default'} 
+      onChange={(key)=>{ this.setState({ [PROJECT.COLOUR_PALETTE]: key }) }} 
+    />
+  </div>
+</Playground>

--- a/src/components/ColorPaletteSwitcher/ColorPaletteSwitcher.scss
+++ b/src/components/ColorPaletteSwitcher/ColorPaletteSwitcher.scss
@@ -1,0 +1,82 @@
+.color-palette-switcher {
+  margin-top: 8px;
+
+  &__option {
+    margin-bottom: 4px;
+    padding: 6px 10px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    transition: all 0.15s ease;
+    cursor: pointer;
+    min-height: 36px;
+    display: flex;
+    align-items: center;
+
+    // Hide the radio button SVG icon from Material-UI
+    span>svg {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      margin: -1px;
+      padding: 0;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0;
+    }
+
+    &:hover {
+      border-color: #999;
+      background-color: rgba(0, 0, 0, 0.03);
+      transform: translateY(-1px);
+    }
+
+    &:focus-within {
+      outline: none;
+      border-color: #3f51b5;
+      box-shadow: 0 0 0 2px rgba(63, 81, 181, 0.2);
+    }
+
+    &.is-selected {
+      border-color: #3f51b5;
+      background-color: rgba(63, 81, 181, 0.08);
+    }
+  }
+
+  &__preview {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    flex: 1;
+    gap: 10px;
+    margin-left: -20px;
+  }
+
+  &__name {
+    font-size: 14px;
+    flex-shrink: 0;
+    min-width: 100px;
+    margin-bottom: 0;
+  }
+
+  &__swatches {
+    display: flex;
+    flex-wrap: nowrap;
+    gap: 3px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+    &::-webkit-scrollbar {
+      display: none;
+    }
+  }
+
+  &__swatch {
+    width: 9px;
+    height: 9px;
+    border-radius: 2px;
+    border: 1px solid rgba(0, 0, 0, 0.15);
+    flex-shrink: 0;
+  }
+}

--- a/src/components/SettingsPopoup/SettingsPopup.jsx
+++ b/src/components/SettingsPopoup/SettingsPopup.jsx
@@ -1,5 +1,5 @@
 import voca from 'voca';
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
@@ -22,50 +22,7 @@ import {
   BUBBLE_STYLES,
 } from '../../constants/project';
 import ColourSwatchPicker from '../ColourSwatchPicker/ColourSwatchPicker';
-import { colourPalettes } from '../../config';
-
-const ColourPaletteSwitcher = ({ currentKey, onChange }) => {
-  const [isOpen, setOpen] = useState(false);
-
-  return (
-    <div
-      onClick={() => setOpen(!isOpen)}
-      style={{ position: 'relative', marginTop: 16 }}
-    >
-      {Object.keys(colourPalettes).map(key => {
-        const pallet = colourPalettes[key];
-        return (
-          <div
-            key={key}
-            onClick={() => onChange(key)}
-            style={{
-              border: key === currentKey ? '1px solid blue' : '1px solid #ddd',
-              marginBottom: 8,
-              padding: 5,
-              borderRadius: 5,
-            }}
-          >
-            <div style={{ fontSize: 14, marginBottom: 8 }}>{pallet.name}</div>
-            {pallet.colours.map(colour => {
-              return (
-                <div
-                  key={colour}
-                  style={{
-                    display: 'inline-block',
-                    margin: 4,
-                    background: colour,
-                    height: 10,
-                    width: 10,
-                  }}
-                />
-              );
-            })}
-          </div>
-        );
-      })}
-    </div>
-  );
-};
+import ColorPaletteSwitcher from '../ColorPaletteSwitcher/ColorPaletteSwitcher';
 
 export default class SettingsPopup extends React.Component {
   static propTypes = {
@@ -119,14 +76,27 @@ export default class SettingsPopup extends React.Component {
   }
 
   keyboardListener = e => {
-    if (e.keyCode === 13) {
+    // Make sure keydown events are captured only when modal is open
+    if (this.props.open && e.keyCode === 13) {
+      if (e.target.tagName === 'BUTTON') {
+        return;
+      }
       e.preventDefault();
       this.onSaveClicked();
     }
   };
 
-  componentDidMount() {
-    document.addEventListener('keydown', this.keyboardListener);
+  /**
+   * Add/Remove 'keydown' event listener when modal opens/closes
+   * @param {Object} prevProps 
+   */
+  componentDidUpdate(prevProps) {
+    if (!prevProps.open && this.props.open) {
+      document.addEventListener('keydown', this.keyboardListener);
+    }
+    if (prevProps.open && !this.props.open) {
+      document.removeEventListener('keydown', this.keyboardListener);
+    }
   }
 
   componentWillUnmount() {
@@ -138,38 +108,26 @@ export default class SettingsPopup extends React.Component {
       <Dialog
         open={this.props.open}
         onClose={this.props.onClose}
-        aria-labelledby="form-dialog-title"
+        aria-labelledby="settings-dialog-title"
         fullWidth={true}
         maxWidth={'md'}
       >
-        <DialogTitle>Settings</DialogTitle>
-        <DialogContent
-          style={{
-            maxWidth: 'none',
-          }}
-        >
-          <div
-            style={{
-              paddingTop: 16,
-              paddingLeft: 8,
-            }}
-          >
+        <DialogTitle id="settings-dialog-title">Settings</DialogTitle>
+        <DialogContent style={{ padding: '12px 20px', maxWidth: 'none' }}>
+          <div style={{ padding: 0 }}>
             <Grid
               container
               direction="row"
               justify="space-between"
               alignItems="stretch"
-              spacing={16}
-              // style={{
-              //   width: 700,
-              // }}
+              spacing={8}
             >
               <Grid item md={6} sm={12}>
                 <Grid
                   container
                   direction="column"
                   justify="flex-start"
-                  spacing={16}
+                  spacing={8}
                 >
                   <Grid item>
                     <FormControl component="fieldset">
@@ -181,17 +139,18 @@ export default class SettingsPopup extends React.Component {
                             'checkbox',
                             'Start playing when bubble or marker is clicked.',
                           ],
-/**                          [
-                            PROJECT.STOP_PLAYING_END_OF_SECTION,
-                            'checkbox',
-                            'Stop Playing at the end of the section.',
-                          ],
-                          [
-                            PROJECT.START_PLAYING_END_OF_SECTION,
-                            'checkbox',
-                            'Loop playback at the end of the section.',
-                          ],
-*/
+                          /** 
+                            [
+                              PROJECT.STOP_PLAYING_END_OF_SECTION,
+                              'checkbox',
+                              'Stop Playing at the end of the section.',
+                            ],
+                            [
+                              PROJECT.START_PLAYING_END_OF_SECTION,
+                              'checkbox',
+                              'Loop playback at the end of the section.',
+                            ],
+                            */
                         ].map(([key, type, label]) => (
                           <FormControlLabel
                             key={key}
@@ -340,20 +299,25 @@ export default class SettingsPopup extends React.Component {
                   container
                   direction="column"
                   justify="flex-start"
-                  spacing={16}
+                  spacing={8}
                 >
                   <Grid item>
-                    <FormLabel component="legend">Color palette</FormLabel>
-                    <ColourPaletteSwitcher
+                    <ColorPaletteSwitcher
                       currentKey={this.state[PROJECT.COLOUR_PALETTE]}
                       onChange={key =>
                         this.setState({ [PROJECT.COLOUR_PALETTE]: key })
                       }
                     />
                   </Grid>
-                  <Button onClick={this.props.clearCustomColors}>
-                    Clear all custom bubble colors
-                  </Button>
+                  <Grid item style={{ marginTop: 6 }}>
+                    <Button
+                      onClick={this.props.clearCustomColors}
+                      variant={'outlined'}
+                      fullWidth
+                    >
+                      Clear all custom bubble colors
+                    </Button>
+                  </Grid>
                 </Grid>
               </Grid>
             </Grid>


### PR DESCRIPTION
Related issue: #78 

Changes in this PR:
- Extract `ColorPaletteSwitcher` component into a separate component
- Add styling for focus indicators and extract inline styling from the jsx into a separate stylesheet
- Use radio button group to build color palette selection UI which creates a more accessible interface


https://github.com/user-attachments/assets/15024dd8-9b7e-4832-bc96-5569eb6598ee

