### PR TITLE
Document steps to bring a timeliner build into Avalon

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ yarn preview
 yarn test
 ```
 
+To test the latest Timeliner code in Avalon follow these steps,
+
+1. Pull the latest code from the `main` branch in GitHub
+1. Run `yarn build` create a new build from the code
+2. Copy contents of `/dist/assets/main-**.css` and `/dist/assets/app-**.css` into
+`/app/javascript/iiif-timeliner-styles.css` in Avalon
+3. Copy contents of `/dist/assets/main-**.js` and `/dist/assets/app-**.js` into `/app/javascript/iiif-timeliner.js` in
+Avalon
+4. Search and remove the `import "./main-**.js"; ` statement in the copied JS content in Avalon
+
+
 ## Links
 
 [Documentation](https://timeliner.dlib.indiana.edu/docs) | [User stories](https://github.com/digirati-co-uk/timeliner/issues?q=is%3Aissue+is%3Aopen+label%3A"%3Abusts_in_silhouette%3A+user+story") | [UX Wireframe](https://preview.uxpin.com/874bd44d74fc6062565cd95dc2dfc9e694b6ed4f#/pages/92279172/simulate/no-panels?mode=i) | [Original timeliner](http://variations.indiana.edu/use/timelines.html) | [Demo site](https://timeliner.dlib.indiana.edu/) | [Changelog](https://github.com/digirati-co-uk/timeliner/issues?q=is%3Aissue+is%3Aclosed+milestone%3A"UI+Components+1.0") 


### PR DESCRIPTION
Document the steps to bring the timeliner build into Avalon in the `README.md`.

Since the `README.md` is more for third-party stakeholders, if there's another better-suited place to put this information other than here, that'd be great as well.